### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ You can run `kubectl get pods` to check that the kubeconfig is recognised.
  metadata:
    generateName: sample-
  spec:
-   restartPolicy: OnFailure
+   restartPolicy: Never
    containers:
    - name: cudasample
      image: nvcr.io/nvidia/k8s/cuda-sample:nbody-cuda11.7.1


### PR DESCRIPTION
Changed RestartPolicy in example from OnFailure to Never. In our setup, pods should by default NOT restart.

Pods automatically being restarted have caused problems for us in the past. If a pod fails, I prefer users to analyse what went wrong and then starting their pod again. Otherwise we end up wasting resources by failing PODs. There are legitimate reasons and scenarios for restarting pods upon failure (e.g., long training runs that reached the time limit before converging), but this is advanced stuff. In this tutorial, we should aim for the desired default behaviour.